### PR TITLE
vsp-renderer: set bytesused in v4l2_buffer

### DIFF
--- a/src/vsp-renderer.c
+++ b/src/vsp-renderer.c
@@ -673,6 +673,33 @@ vsp_dequeue_buffer(int fd, int capture)
 	return 0;
 }
 
+static inline unsigned int
+vsp_plane_height(int plane, int height, unsigned int format)
+{
+	switch (plane) {
+	case 0:
+		return height;
+	case 1:
+		switch (format) {
+		case V4L2_PIX_FMT_NV12M:
+		case V4L2_PIX_FMT_NV21M:
+		case V4L2_PIX_FMT_YUV420M:
+			return height / 2;
+		case V4L2_PIX_FMT_NV16M:
+		case V4L2_PIX_FMT_NV61M:
+			return height;
+		}
+		break;
+	case 2:
+		switch (format) {
+		case V4L2_PIX_FMT_YUV420M:
+			return height / 2;
+		}
+		break;
+	}
+	return 0;
+}
+
 static int
 vsp_queue_buffer(int fd, int capture, struct vsp_surface_state *vs)
 {
@@ -687,8 +714,12 @@ vsp_queue_buffer(int fd, int capture, struct vsp_surface_state *vs)
 	buf.m.planes = planes;
 	buf.length = vs->base.num_planes;
 	memset(planes, 0, sizeof(planes));
-	for (i = 0; i < vs->base.num_planes; i++)
+	for (i = 0; i < vs->base.num_planes; i++) {
 		buf.m.planes[i].m.fd = vs->base.planes[i].dmafd;
+		buf.m.planes[i].bytesused = vs->base.planes[i].stride *
+			vsp_plane_height(i, vs->base.height,
+					 vs->base.pixel_format);
+	}
 
 	if (ioctl(fd, VIDIOC_QBUF, &buf) == -1) {
 		weston_log("VIDIOC_QBUF failed for dmafd=%d(%d planes) on %d (%s).\n",


### PR DESCRIPTION
Specifying zero for the bytesused in v4l2_buffer is deprecated in the
linux kernel 4.1 or later. We shall set bytesused value explicitly.
