### PR TITLE
v4l2-renderer: Release dma-buf when attaching null buffer

### DIFF
--- a/libweston/v4l2-renderer.c
+++ b/libweston/v4l2-renderer.c
@@ -1671,6 +1671,12 @@ v4l2_renderer_attach(struct weston_surface *es, struct weston_buffer *buffer)
 			weston_buffer_reference(&vs->buffer_ref, NULL);
 			return;
 		}
+	} else {
+		// null buffer is a special case: current buffer needs to be
+		// released, so reference counter of the attached
+		// dma buffer is dropped from us now
+		v4l2_release_dmabuf(vs);
+		v4l2_release_kms_bo(vs);
 	}
 
 #ifdef V4L2_GL_FALLBACK_ENABLED


### PR DESCRIPTION
When renderer is requested to attach a null buffer, e.g. via
wl_surface_attach with wl_buffer pointer set to null, it is
expected that the current buffer is released, effectively
dropping our reference on the attached dma buffer. Otherwise,
the reference is kept until the renderer is destroyed preventing
the dma buffer from being released earlier.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>