### PR TITLE
v4l2-renderer: Introduce detach_buffer op to v4l2_device_interface

### DIFF
--- a/libweston/v4l2-renderer-device.h
+++ b/libweston/v4l2-renderer-device.h
@@ -131,6 +131,7 @@ struct v4l2_device_interface {
 
 	struct v4l2_surface_state *(*create_surface)(struct v4l2_renderer_device *dev);
 	int (*attach_buffer)(struct v4l2_surface_state *vs);
+	void (*detach_buffer)(struct v4l2_renderer_device *dev, struct v4l2_surface_state *vs);
 
 	bool (*begin_compose)(struct v4l2_renderer_device *dev, struct v4l2_renderer_output *out);
 	void (*finish_compose)(struct v4l2_renderer_device *dev);

--- a/libweston/v4l2-renderer.c
+++ b/libweston/v4l2-renderer.c
@@ -1689,7 +1689,11 @@ v4l2_renderer_attach(struct weston_surface *es, struct weston_buffer *buffer)
 	} else {
 		// null buffer is a special case: current buffer needs to be
 		// released, so reference counter of the attached
-		// dma buffer is dropped from us now
+		// dma buffer is dropped from us now,
+		// also we ask renderer backend device to completely release
+		// the attached dma buffer if it is still in use
+
+		device_interface->detach_buffer(vs->renderer->device, vs);
 		v4l2_release_dmabuf(vs);
 		v4l2_release_kms_bo(vs);
 	}


### PR DESCRIPTION
Extend v4l2_device_interface by adding detach_buffer operation
the main purpose of which is to ask renderer backend device
to completely release attached dma buffer if it is still in use.
There may be a case when no new composition is going to be done
later and we may end up with dma buffer which has never been released
(actually what we observe when using ivi-shell).

Call this operation if client asks to release current buffer
by attaching null buffer to the surface.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>